### PR TITLE
fix images do not match error

### DIFF
--- a/scripts/face_editor.py
+++ b/scripts/face_editor.py
@@ -224,8 +224,8 @@ class Script(scripts.Script):
         faces = faces[:max_face_count]
         entire_mask_image = np.zeros_like(entire_image)
 
-        entire_width = p.width
-        entire_height = p.height
+        entire_width = (p.width // 8) * 8
+        entire_height = (p.height // 8) * 8
         entire_prompt = p.prompt
         p.batch_size = 1
         p.n_iter = 1


### PR DESCRIPTION
The height and width of the image used for inpainting must be multiples of 8 each, or an error will occur, forcing a change to multiples of 8.
Issue: #15 