### PR TITLE
use List[str] from build in typing module instead list[str]

### DIFF
--- a/scripts/face_editor.py
+++ b/scripts/face_editor.py
@@ -1,4 +1,5 @@
 from operator import attrgetter
+from typing import List
 
 import cv2
 import gradio as gr
@@ -553,7 +554,7 @@ class Script(scripts.Script):
             return wp.all_prompts[0]
         return prompt
 
-    def __get_face_prompts(self, length: int, prompt_for_face: str, entire_prompt: str) -> list[str]:
+    def __get_face_prompts(self, length: int, prompt_for_face: str, entire_prompt: str) -> List[str]:
         if len(prompt_for_face) == 0:
             return [entire_prompt] * length
         prompts = []


### PR DESCRIPTION
I was getting a following error with python3.8.

```
  File "/sandbox/auto1111/stable-diffusion-webui/extensions/sd-face-editor/scripts/face_editor.py", line 556, in Script
    def __get_face_prompts(self, length: int, prompt_for_face: str, entire_prompt: str) -> list[str]:
TypeError: 'type' object is not subscriptable
```

Fixed using typing module.

