### PR TITLE
custom order of scripts

### DIFF
--- a/scripts/entities/option.py
+++ b/scripts/entities/option.py
@@ -16,7 +16,6 @@ class Option:
     DEFAULT_USE_MINIMAL_AREA = False
     DEFAULT_IGNORE_LARGER_FACES = True
     DEFAULT_AFFECTED_AREAS = ["Face"]
-    DEFAULT_SCRIPT_INDEX = -1
 
     def __init__(self, *args) -> None:
         self.face_margin = Option.DEFAULT_FACE_MARGIN
@@ -36,7 +35,6 @@ class Option:
         self.ignore_larger_faces = Option.DEFAULT_IGNORE_LARGER_FACES
         self.affected_areas = Option.DEFAULT_AFFECTED_AREAS
         self.show_original_image = Option.DEFAULT_SHOW_ORIGINAL_IMAGE
-        self.script_index = Option.DEFAULT_SCRIPT_INDEX
 
         if len(args) > 0 and isinstance(args[0], dict):
             self.update_by_dict(args[0])
@@ -70,7 +68,6 @@ class Option:
         self.ignore_larger_faces = args[14] if arg_len > 14 and isinstance(args[14], bool) else self.ignore_larger_faces
         self.affected_areas = args[15] if arg_len > 15 and isinstance(args[15], list) else self.affected_areas
         self.show_original_image = args[16] if arg_len > 16 and isinstance(args[16], bool) else self.show_original_image
-        self.script_index = args[17] if arg_len > 17 and isinstance(args[17], int) else self.script_index
 
     def update_by_dict(self, params: dict) -> None:
         self.face_margin = params.get("face_margin", self.face_margin)
@@ -90,7 +87,6 @@ class Option:
         self.ignore_larger_faces = params.get("ignore_larger_faces", self.ignore_larger_faces)
         self.affected_areas = params.get("affected_areas", self.affected_areas)
         self.show_original_image = params.get("show_original_image", self.show_original_image)
-        self.script_index = params.get("script_index", self.script_index)
 
     def to_dict(self) -> dict:
         return {
@@ -110,7 +106,6 @@ class Option:
             Option.add_prefix("ignore_larger_faces"): self.ignore_larger_faces,
             Option.add_prefix("affected_areas"): str.join(";", self.affected_areas),
             Option.add_prefix("show_original_image"): self.show_original_image,
-            Option.add_prefix("script_index"): self.script_index,
         }
 
     @staticmethod

--- a/scripts/entities/option.py
+++ b/scripts/entities/option.py
@@ -105,7 +105,6 @@ class Option:
             Option.add_prefix("use_minimal_area"): self.use_minimal_area,
             Option.add_prefix("ignore_larger_faces"): self.ignore_larger_faces,
             Option.add_prefix("affected_areas"): str.join(";", self.affected_areas),
-            Option.add_prefix("show_original_image"): self.show_original_image,
         }
 
     @staticmethod

--- a/scripts/entities/option.py
+++ b/scripts/entities/option.py
@@ -16,6 +16,7 @@ class Option:
     DEFAULT_USE_MINIMAL_AREA = False
     DEFAULT_IGNORE_LARGER_FACES = True
     DEFAULT_AFFECTED_AREAS = ["Face"]
+    DEFAULT_SCRIPT_INDEX = -1
 
     def __init__(self, *args) -> None:
         self.face_margin = Option.DEFAULT_FACE_MARGIN
@@ -35,6 +36,7 @@ class Option:
         self.ignore_larger_faces = Option.DEFAULT_IGNORE_LARGER_FACES
         self.affected_areas = Option.DEFAULT_AFFECTED_AREAS
         self.show_original_image = Option.DEFAULT_SHOW_ORIGINAL_IMAGE
+        self.script_index = Option.DEFAULT_SCRIPT_INDEX
 
         if len(args) > 0 and isinstance(args[0], dict):
             self.update_by_dict(args[0])
@@ -68,6 +70,7 @@ class Option:
         self.ignore_larger_faces = args[14] if arg_len > 14 and isinstance(args[14], bool) else self.ignore_larger_faces
         self.affected_areas = args[15] if arg_len > 15 and isinstance(args[15], list) else self.affected_areas
         self.show_original_image = args[16] if arg_len > 16 and isinstance(args[16], bool) else self.show_original_image
+        self.script_index = args[17] if arg_len > 17 and isinstance(args[17], int) else self.script_index
 
     def update_by_dict(self, params: dict) -> None:
         self.face_margin = params.get("face_margin", self.face_margin)
@@ -87,6 +90,7 @@ class Option:
         self.ignore_larger_faces = params.get("ignore_larger_faces", self.ignore_larger_faces)
         self.affected_areas = params.get("affected_areas", self.affected_areas)
         self.show_original_image = params.get("show_original_image", self.show_original_image)
+        self.script_index = params.get("script_index", self.script_index)
 
     def to_dict(self) -> dict:
         return {
@@ -105,6 +109,8 @@ class Option:
             Option.add_prefix("use_minimal_area"): self.use_minimal_area,
             Option.add_prefix("ignore_larger_faces"): self.ignore_larger_faces,
             Option.add_prefix("affected_areas"): str.join(";", self.affected_areas),
+            Option.add_prefix("show_original_image"): self.show_original_image,
+            Option.add_prefix("script_index"): self.script_index,
         }
 
     @staticmethod

--- a/scripts/face_editor_extension.py
+++ b/scripts/face_editor_extension.py
@@ -30,11 +30,22 @@ class FaceEditorExtension(scripts.Script):
         if not option.save_original_image:
             p.do_not_save_samples = True
 
-        if p.scripts is not None and hasattr(p.scripts, "alwayson_scripts") and p.scripts.alwayson_scripts[-1] != self:
-            for i, e in enumerate(p.scripts.alwayson_scripts):
-                if e == self:
-                    p.scripts.alwayson_scripts.append(p.scripts.alwayson_scripts.pop(i))
-                    break
+        if p.scripts is None and not hasattr(p.scripts, "alwayson_scripts"):
+            return
+                
+        if p.scripts.alwayson_scripts[option.script_index] == self:
+            return
+        
+        for i, e in enumerate(p.scripts.alwayson_scripts):
+            if e != self:
+                continue
+
+            p.scripts.alwayson_scripts.pop(i)
+            if option.script_index == -1:
+                p.scripts.alwayson_scripts.append(self)
+            else:
+                p.scripts.alwayson_scripts.insert(option.script_index + 1, self)
+
 
     def postprocess(self, o, res, enabled, *args):
         if not enabled or self.__is_running:

--- a/scripts/face_editor_extension.py
+++ b/scripts/face_editor_extension.py
@@ -32,7 +32,10 @@ class FaceEditorExtension(scripts.Script):
 
         if p.scripts is None and not hasattr(p.scripts, "alwayson_scripts"):
             return
-                
+        
+        if option.script_index >= len(p.scripts.alwayson_scripts) or option.script_index < -len(p.scripts.alwayson_scripts):
+            return
+        
         if p.scripts.alwayson_scripts[option.script_index] == self:
             return
         

--- a/scripts/face_editor_extension.py
+++ b/scripts/face_editor_extension.py
@@ -30,27 +30,13 @@ class FaceEditorExtension(scripts.Script):
         option = Option(*args)
         if not option.save_original_image:
             p.do_not_save_samples = True
-
-        if p.scripts is None and not hasattr(p.scripts, "alwayson_scripts"):
-            return
-        
-        script_index = shared.opts.data.get("face_editor_script_index", -1)
-        if script_index >= len(p.scripts.alwayson_scripts) or script_index < -len(p.scripts.alwayson_scripts):
-            return
-        
-        if p.scripts.alwayson_scripts[script_index] == self:
-            return
-        
-        for i, e in enumerate(p.scripts.alwayson_scripts):
-            if e != self:
-                continue
-
-            p.scripts.alwayson_scripts.pop(i)
-            if script_index == -1:
-                p.scripts.alwayson_scripts.append(self)
-            else:
-                p.scripts.alwayson_scripts.insert(script_index + 1, self)
-
+                
+        if p.scripts is not None and hasattr(p.scripts, "alwayson_scripts"):
+            script_index = shared.opts.data.get("face_editor_script_index", 99)
+            for i, e in enumerate(p.scripts.alwayson_scripts):
+                if e == self:
+                    p.scripts.alwayson_scripts.insert(script_index, p.scripts.alwayson_scripts.pop(i))
+                    break
 
     def postprocess(self, o, res, enabled, *args):
         if not enabled or self.__is_running:

--- a/scripts/face_editor_extension.py
+++ b/scripts/face_editor_extension.py
@@ -1,5 +1,6 @@
 import modules.scripts as scripts
 
+from modules import shared
 from scripts.entities.option import Option
 from scripts.inferencers.factory import InferencerFactory
 from scripts.ui.ui_builder import UiBuilder
@@ -33,10 +34,11 @@ class FaceEditorExtension(scripts.Script):
         if p.scripts is None and not hasattr(p.scripts, "alwayson_scripts"):
             return
         
-        if option.script_index >= len(p.scripts.alwayson_scripts) or option.script_index < -len(p.scripts.alwayson_scripts):
+        script_index = shared.opts.data.get("face_editor_script_index", -1)
+        if script_index >= len(p.scripts.alwayson_scripts) or script_index < -len(p.scripts.alwayson_scripts):
             return
         
-        if p.scripts.alwayson_scripts[option.script_index] == self:
+        if p.scripts.alwayson_scripts[script_index] == self:
             return
         
         for i, e in enumerate(p.scripts.alwayson_scripts):
@@ -44,10 +46,10 @@ class FaceEditorExtension(scripts.Script):
                 continue
 
             p.scripts.alwayson_scripts.pop(i)
-            if option.script_index == -1:
+            if script_index == -1:
                 p.scripts.alwayson_scripts.append(self)
             else:
-                p.scripts.alwayson_scripts.insert(option.script_index + 1, self)
+                p.scripts.alwayson_scripts.insert(script_index + 1, self)
 
 
     def postprocess(self, o, res, enabled, *args):

--- a/scripts/ui/ui_builder.py
+++ b/scripts/ui/ui_builder.py
@@ -1,5 +1,6 @@
 import gradio as gr
 
+from modules import shared, script_callbacks
 from scripts.entities.option import Option
 from scripts.ui.param_value_parser import ParamValueParser
 
@@ -129,16 +130,6 @@ class UiBuilder:
                 )
                 self.infotext_fields.append((strength2, Option.add_prefix("strength2")))
 
-            with gr.Accordion("(6) Script Execution Order", open=False):
-                script_index = gr.Slider(
-                    label="Script Execution Position Index(0 is the first script, -1 is the last script to execute, etc.)",
-                    minimum=-10,
-                    maximum=10,
-                    step=1,
-                    value=Option.DEFAULT_SCRIPT_INDEX,
-                )
-                self.infotext_fields.append((script_index, Option.add_prefix("script_index")))
-
         return [
             face_margin,
             confidence,
@@ -157,5 +148,12 @@ class UiBuilder:
             ignore_larger_faces,
             affected_areas,
             show_original_image,
-            script_index,
         ]
+
+
+def on_ui_settings():
+    section = ('face_editor', "FaceEditor")
+    shared.opts.add_option("face_editor_script_index", shared.OptionInfo(-1, "Script Execution Position Index(0 is the first script, -1 is the last script to execute, etc.)", gr.Slider, {"minimum": -10, "maximum": 10, "step": 1}, section=section))
+
+
+script_callbacks.on_ui_settings(on_ui_settings)

--- a/scripts/ui/ui_builder.py
+++ b/scripts/ui/ui_builder.py
@@ -129,6 +129,16 @@ class UiBuilder:
                 )
                 self.infotext_fields.append((strength2, Option.add_prefix("strength2")))
 
+            with gr.Accordion("(6) Script Execution Order", open=False):
+                script_index = gr.Slider(
+                    label="Script Execution Position Index",
+                    minimum=-10,
+                    maximum=10,
+                    step=1,
+                    value=Option.DEFAULT_SCRIPT_INDEX,
+                )
+                self.infotext_fields.append((script_index, Option.add_prefix("script_index")))
+
         return [
             face_margin,
             confidence,
@@ -147,4 +157,5 @@ class UiBuilder:
             ignore_larger_faces,
             affected_areas,
             show_original_image,
+            script_index,
         ]

--- a/scripts/ui/ui_builder.py
+++ b/scripts/ui/ui_builder.py
@@ -152,7 +152,7 @@ class UiBuilder:
 
 
 def on_ui_settings():
-    section = ('face_editor', "FaceEditor")
+    section = ('face_editor', "Face Editor")
     shared.opts.add_option("face_editor_script_index", shared.OptionInfo(-1, "Script Execution Position Index(0 is the first script, -1 is the last script to execute, etc.)", gr.Slider, {"minimum": -10, "maximum": 10, "step": 1}, section=section))
 
 

--- a/scripts/ui/ui_builder.py
+++ b/scripts/ui/ui_builder.py
@@ -131,7 +131,7 @@ class UiBuilder:
 
             with gr.Accordion("(6) Script Execution Order", open=False):
                 script_index = gr.Slider(
-                    label="Script Execution Position Index",
+                    label="Script Execution Position Index(0 is the first script, -1 is the last script to execute, etc.)",
                     minimum=-10,
                     maximum=10,
                     step=1,

--- a/scripts/ui/ui_builder.py
+++ b/scripts/ui/ui_builder.py
@@ -153,7 +153,7 @@ class UiBuilder:
 
 def on_ui_settings():
     section = ('face_editor', "Face Editor")
-    shared.opts.add_option("face_editor_script_index", shared.OptionInfo(-1, "Script Execution Position Index(0 is the first script, -1 is the last script to execute, etc.)", gr.Slider, {"minimum": -10, "maximum": 10, "step": 1}, section=section))
+    shared.opts.add_option("face_editor_script_index", shared.OptionInfo(99, "Script Execution Position Index(0 means the first, 99 means the last script to execute, etc.)", gr.Slider, {"minimum": 0, "maximum": 99, "step": 1}, section=section))
 
 
 script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
Sometimes it is necessary to perform other operations after fixing the face, such as cropping the avatar and changing various outfits, so I want to add a parameter to adjust the execution order for this extension, which defaults to executing last.

- Option: script_index
- p.scripts.alwayson_scripts execute order