### PR TITLE
fix error in fallback mask generation

### DIFF
--- a/scripts/inferencers/bisenet_mask_generator.py
+++ b/scripts/inferencers/bisenet_mask_generator.py
@@ -30,6 +30,7 @@ class BiSeNetMaskGenerator(MaskGenerator):
         fallback_ratio: float = 0.25,
         **kwargs,
     ) -> np.ndarray:
+        original_face_image = face_image
         face_image = face_image.copy()
 
         if use_minimal_area:
@@ -59,7 +60,9 @@ class BiSeNetMaskGenerator(MaskGenerator):
             mask = cv2.resize(mask, dsize=(w, h))
 
         if MaskGenerator.calculate_mask_coverage(mask) < fallback_ratio:
-            mask = self.fallback_mask_generator.generate_mask(face_image, face_area_on_image, use_minimal_area=True)
+            mask = self.fallback_mask_generator.generate_mask(
+                original_face_image, face_area_on_image, use_minimal_area=True
+            )
 
         return mask
 


### PR DESCRIPTION
Fixed an error that occurred in combination with the following conditions

- When the size specified in "Size of the face when recreating" is other than 512
- BiSeNetMaskGenerator is used.
- VignetteMaskGenerator worked on fallback