### PR TITLE
upgrade this extension's dependency

### DIFF
--- a/install.py
+++ b/install.py
@@ -23,6 +23,6 @@ if shared.opts.data.get("face_editor_additional_components", None) is not None:
             print(f"Face Editor: {e}")
 
 launch.run_pip(
-    "install lark-parser",
+    "install lark",
     "requirements for Face Editor",
 )


### PR DESCRIPTION
- sd-face-editor currently uses lark-parser as dependency
- sd-webui (v1.5.1) uses lark as dependency, which is a newer version of lark-parser
- by upgrading to match up with the same dependency as sd-webui's, this PR will avoid the tricky errors (generated around the prompt editing feature) caused by the difference versions of lark parser