### PR TITLE
Update for new forge

### DIFF
--- a/face_editor/entities/definitions.py
+++ b/face_editor/entities/definitions.py
@@ -9,6 +9,8 @@ class Worker(BaseModel):
 
     @root_validator(pre=True)
     def default_params(cls, values):
+        if isinstance(values, list):
+            values = {str(i): v for i, v in enumerate(values)}
         if "params" not in values or values["params"] is None:
             values["params"] = {}
         return values


### PR DESCRIPTION
resolve #197

Already test it on `forge` and `AUTOMATIC1111`  and find no problem.

 In the `definitions.py` file, I modified the default_params method of the Worker class to ensure values is a dictionary before assigning to its "params" key. If values is a list, it is converted into a dictionary where the list indices serve as dictionary keys and list values as dictionary values. This resolves the `TypeError: list indices must be integers or slices, not str error`. 
